### PR TITLE
update dependencies

### DIFF
--- a/packages/doc/package.json
+++ b/packages/doc/package.json
@@ -6,8 +6,8 @@
     "build": "htmlgaga build"
   },
   "devDependencies": {
-    "@htmlgaga/plugin-react-helmet": "workspace:*",
-    "htmlgaga": "workspace:*",
+    "@htmlgaga/plugin-react-helmet": "^0.1.4",
+    "htmlgaga": "^0.8.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-helmet": "^6.0.0"


### PR DESCRIPTION
Update dependencies because Vercel won't work with yarn 2's `workspace:*`.