### PR TITLE
fix for preconstruct build

### DIFF
--- a/packages/htmlgaga/src/index.ts
+++ b/packages/htmlgaga/src/index.ts
@@ -66,8 +66,7 @@ yargs
         rimraf(path.resolve(cwd, '.htmlgaga'), async (err) => {
           if (err) return logger.error(err)
           const builder = new Builder(pagesDir, outDir)
-          // FIXME, https://github.com/preconstruct/preconstruct/issues/267
-          // process.env.NODE_ENV = 'production'
+          process.env['NODE_ENV'] = 'production'
           await builder.run()
         })
       })


### PR DESCRIPTION
Got error when use `process.env.NODE_ENV = 'production'`:

```
🎁 info building bundles!
🎁 error htmlgaga Error: Assigning to rvalue (Note that you need plugins to import files that are not JavaScript)
🎁 error htmlgaga     at error (/Users/sam/Documents/githubRepos/htmlgaga/node_modules/rollup/dist/shared/node-entry.js:5400:30)
🎁 error htmlgaga     at Module.error (/Users/sam/Documents/githubRepos/htmlgaga/node_modules/rollup/dist/shared/node-entry.js:9824:16)
🎁 error htmlgaga     at tryParse (/Users/sam/Documents/githubRepos/htmlgaga/node_modules/rollup/dist/shared/node-entry.js:9717:23)
🎁 error htmlgaga     at Module.setSource (/Users/sam/Documents/githubRepos/htmlgaga/node_modules/rollup/dist/shared/node-entry.js:10080:33)
🎁 error htmlgaga     at /Users/sam/Documents/githubRepos/htmlgaga/node_modules/rollup/dist/shared/node-entry.js:12366:20
🎁 error htmlgaga     at processTicksAndRejections (internal/process/task_queues.js:97:5)
🎁 error htmlgaga     at async Promise.all (index 0)
🎁 error htmlgaga     at async Promise.all (index 0)
🎁 error htmlgaga     at async Promise.all (index 0) {
🎁 error htmlgaga   code: 'PARSE_ERROR',
🎁 error htmlgaga   parserError: SyntaxError: Assigning to rvalue (52:6)
🎁 error htmlgaga       at Object.pp$4.raise (/Users/sam/Documents/githubRepos/htmlgaga/node_modules/acorn/dist/acorn.js:2840:15)
🎁 error htmlgaga       at Object.pp$2.toAssignable (/Users/sam/Documents/githubRepos/htmlgaga/node_modules/acorn/dist/acorn.js:1693:14)
🎁 error htmlgaga       at Object.pp$3.parseMaybeAssign (/Users/sam/Documents/githubRepos/htmlgaga/node_modules/acorn/dist/acorn.js:1974:49)
🎁 error htmlgaga       at Object.pp$3.parseExpression (/Users/sam/Documents/githubRepos/htmlgaga/node_modules/acorn/dist/acorn.js:1935:21)
🎁 error htmlgaga       at Object.pp$1.parseStatement (/Users/sam/Documents/githubRepos/htmlgaga/node_modules/acorn/dist/acorn.js:877:47)
🎁 error htmlgaga       at Object.parseStatement (/Users/sam/Documents/githubRepos/htmlgaga/node_modules/rollup/dist/shared/node-entry.js:11829:30)
🎁 error htmlgaga       at Object.pp$1.parseBlock (/Users/sam/Documents/githubRepos/htmlgaga/node_modules/acorn/dist/acorn.js:1161:23)
🎁 error htmlgaga       at Object.pp$3.parseFunctionBody (/Users/sam/Documents/githubRepos/htmlgaga/node_modules/acorn/dist/acorn.js:2686:24)
🎁 error htmlgaga       at Object.pp$3.parseArrowExpression (/Users/sam/Documents/githubRepos/htmlgaga/node_modules/acorn/dist/acorn.js:2649:10)
🎁 error htmlgaga       at Object.pp$3.parseExprAtom (/Users/sam/Documents/githubRepos/htmlgaga/node_modules/acorn/dist/acorn.js:2201:23) {
🎁 error htmlgaga     pos: 1432,
🎁 error htmlgaga     loc: Position { line: 52, column: 6 },
🎁 error htmlgaga     raisedAt: 1446
🎁 error htmlgaga   },
🎁 error htmlgaga   pos: 1432,
🎁 error htmlgaga   loc: {
🎁 error htmlgaga     column: 10,
🎁 error htmlgaga     file: '/Users/sam/Documents/githubRepos/htmlgaga/packages/htmlgaga/src/index.ts',
🎁 error htmlgaga     line: 70
🎁 error htmlgaga   },
🎁 error htmlgaga   frame: '68:           const builder = new Builder(pagesDir, outDir)\n' +
🎁 error htmlgaga     '69:           // FIXME, https://github.com/preconstruct/preconstruct/issues/267\n' +
🎁 error htmlgaga     "70:           process.env.NODE_ENV = 'production'\n" +
🎁 error htmlgaga     '              ^\n' +
🎁 error htmlgaga     '71:           await builder.run()\n' +
🎁 error htmlgaga     '72:         })',
🎁 error htmlgaga   watchFiles: [
🎁 error htmlgaga     '/Users/sam/Documents/githubRepos/htmlgaga/packages/htmlgaga/src/index.ts',
🎁 error htmlgaga     '/Users/sam/Documents/githubRepos/htmlgaga/packages/htmlgaga/src/Client/index.ts',
🎁 error htmlgaga     '/Users/sam/Documents/githubRepos/htmlgaga/packages/htmlgaga/src/devTemplate/index.ts'
🎁 error htmlgaga   ]
🎁 error htmlgaga }
🎁 info If want to learn more about the above error, check https://preconstruct.tools/errors
🎁 info If the error is not there and you want to learn more about it, open an issue at https://github.com/preconstruct/preconstruct/issues/new
```