### PR TITLE
fix filename

### DIFF
--- a/packages/htmlgaga/src/config.ts
+++ b/packages/htmlgaga/src/config.ts
@@ -93,7 +93,7 @@ export const rules = [
     test: /\.(png|svg|jpg|gif)$/i,
     type: 'asset',
     generator: {
-      filename: '[name].[contenthash].[ext]',
+      filename: '[name].[hash][ext]',
     },
   },
   {


### PR DESCRIPTION
Unfortunately the [`filename`](https://webpack.js.org/configuration/module/#rulegeneratorfilename) does not support `contenthash` as far as I tested.