### PR TITLE
use file-loader for the time being

### DIFF
--- a/packages/htmlgaga-styles/package.json
+++ b/packages/htmlgaga-styles/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@types/react": "16.9.41",
     "@types/react-dom": "16.9.8",
-    "htmlgaga": "0.11.9",
+    "htmlgaga": "0.11.10",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
   }

--- a/packages/htmlgaga/CHANGELOG.md
+++ b/packages/htmlgaga/CHANGELOG.md
@@ -1,5 +1,11 @@
 # htmlgaga
 
+## 0.11.10
+
+### Patch Changes
+
+- fix assets.json
+
 ## 0.11.9
 
 ### Patch Changes

--- a/packages/htmlgaga/package.json
+++ b/packages/htmlgaga/package.json
@@ -1,6 +1,6 @@
 {
   "name": "htmlgaga",
-  "version": "0.11.9",
+  "version": "0.11.10",
   "description": "Manage non-SPA pages with webpack and React.js",
   "main": "dist/htmlgaga.cjs.js",
   "module": "dist/htmlgaga.esm.js",

--- a/packages/htmlgaga/src/config.ts
+++ b/packages/htmlgaga/src/config.ts
@@ -97,14 +97,9 @@ export const rules = [
   },
   {
     test: /\.(png|svg|jpg|jpeg|gif)$/i,
-    type: 'asset',
-    generator: {
-      filename: '[name].[hash][ext]',
-    },
-    parser: {
-      dataUrlCondition: {
-        maxSize: 1024,
-      },
+    loader: 'file-loader',
+    options: {
+      name: '[name].[contenthash].[ext]',
     },
   },
   {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2217,7 +2217,7 @@ __metadata:
   dependencies:
     "@types/react": 16.9.41
     "@types/react-dom": 16.9.8
-    htmlgaga: 0.11.9
+    htmlgaga: 0.11.10
     react: ^16.13.1
     react-dom: ^16.13.1
   languageName: unknown
@@ -7580,7 +7580,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"htmlgaga@0.11.9, htmlgaga@^0.11.1, htmlgaga@workspace:packages/htmlgaga":
+"htmlgaga@0.11.10, htmlgaga@^0.11.1, htmlgaga@workspace:packages/htmlgaga":
   version: 0.0.0-use.local
   resolution: "htmlgaga@workspace:packages/htmlgaga"
   dependencies:


### PR DESCRIPTION
Currently `webpack-manifest-plugin` doesn't handle [asset modules](https://webpack.js.org/guides/asset-modules/#root) which means we'll have `hash` encoded in key of [`assets.json`](https://github.com/chenxsan/htmlgaga/blob/master/packages/doc/out/assets.json#L9) https://github.com/chenxsan/htmlgaga/blob/1b336827915789e0c78837053574b4a5c6deaa27/packages/doc/out/assets.json#L9

which is inconvenient when we use the out html pages on server side.